### PR TITLE
DDF-1197 created an HTTP to HTTPS proxy to use for legacy clients

### DIFF
--- a/httpproxy/proxy-camel-route/pom.xml
+++ b/httpproxy/proxy-camel-route/pom.xml
@@ -70,7 +70,7 @@
             	org.apache.camel.core.osgi,
             	*
             </Import-Package>
-            <Embed-Dependency>camel-servlet, camel-core-osgi</Embed-Dependency>
+            <Embed-Dependency>camel-servlet, camel-core-osgi, camel-jetty</Embed-Dependency>
             <Export-Package>
             	org.apache.camel.component.servlet,
             	org.apache.camel.core.osgi,


### PR DESCRIPTION
 - added new HTTP to HTTPS camel proxy service
 - added integration test for anonymous SOAP HTTP access
 - disabled HTTP in pax web configuration file

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-libs/5)
<!-- Reviewable:end -->
